### PR TITLE
Write Curator and Kibana Cookbooks, Massive Refactoring, Define Role

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,3 +13,5 @@ suites:
     run_list:
       - recipe[elasticsearch]
       - recipe[logstash]
+      - recipe[curator]
+      - recipe[kibana]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,7 +11,4 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[elasticsearch]
-      - recipe[logstash]
-      - recipe[curator]
-      - recipe[kibana]
+      - role[delk]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,4 +15,6 @@ Log format:
 - Change log, for better version and change tracking
 - Elasticstack cookbook (complete)
 - Logstash cookbook (complete)
+- Curator cookbook (complete)
+- Kibana cookbook (complete)
 - Add more information about DELK in `README.md`

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ inside a Vagrant box, provisioned by Chef and Kitchen.
 
 - [x] Elasticsearch
 - [x] Logstash
-- [ ] Kibana
-- [ ] Curator
+- [x] Kibana
+- [x] Curator
 - [ ] Maintenance scripts
+- [ ] rsyslog forwarder
 
 
 # License

--- a/cookbooks/curator/README.md
+++ b/cookbooks/curator/README.md
@@ -1,6 +1,6 @@
-# Dockerized Logstash cookbook
+# Dockerized Curator cookbook
 
-This cookbooks sets up a basic Logstash configuration, ready to be
+This cookbooks sets up a basic Curator configuration, ready to be
 invoked using a Docker Compose configuration file, or manually by
 invoking the `docker` command and setting up volumes and port forwarding
 using the command line.
@@ -25,15 +25,13 @@ Depends on `elasticsearch` cookbook, version `~>0.0.1`.
 
 ## Attributes
 
-- `node["logstash"]["dir"]` - directory where Logstash keeps its
-  configuration and data, default: `~/logstash`
-- `node["logstash"]["port"]` - port used for communication,
-  default: `5000`
+- `node["curator"]["dir"]` - directory where Curator keeps its
+  configuration and data, default: `~/curator`
 
 
 ## Recipes
 
-One recipe provided for invocation: `logstash::default`.
+One recipe provided for invocation: `curator::default`.
 
 
 ## License and Maintainer

--- a/cookbooks/curator/attributes/default.rb
+++ b/cookbooks/curator/attributes/default.rb
@@ -1,0 +1,3 @@
+# Attributes for Curator
+
+default["curator"]["dir"] = "/home/vagrant/curator"

--- a/cookbooks/curator/attributes/default.rb
+++ b/cookbooks/curator/attributes/default.rb
@@ -1,3 +1,3 @@
 # Attributes for Curator
 
-default["curator"]["dir"] = "/home/vagrant/curator"
+default["curator"]["dir"] = "/home/#{node["delk_user"]}/curator"

--- a/cookbooks/curator/metadata.rb
+++ b/cookbooks/curator/metadata.rb
@@ -1,0 +1,4 @@
+name    'curator'
+version '0.0.1'
+
+depends 'elasticsearch', '>=0.0.1'

--- a/cookbooks/curator/recipes/default.rb
+++ b/cookbooks/curator/recipes/default.rb
@@ -21,16 +21,23 @@ apt_package "elasticsearch-curator"
 
 
 # Create its directory
-directory "#{node["curator"]["dir"]}"
+directory "#{node["curator"]["dir"]}" do
+  owner node["delk_user"]
+  group node["delk_user"]
+end
 
 
 # Generate the configuration files from templates
 template "#{node["curator"]["dir"]}/actions.yml" do
   source "actions.yml.erb"
+  owner node["delk_user"]
+  group node["delk_user"]
 end
 
 template "#{node["curator"]["dir"]}/config.yml" do
   source "config.yml.erb"
+  owner node["delk_user"]
+  group node["delk_user"]
   variables({
     elasticsearch_host: node["elasticsearch"]["hostname"],
     elasticsearch_port: node["elasticsearch"]["port_api"]
@@ -41,7 +48,7 @@ end
 # Generate cron file for periodic, automatic invocation
 template "/etc/cron.d/curator-maintenance" do
   source "curator-maintenance.erb"
-  mode '0755'
+  mode "0755"
   variables({
     curator_dir:        node["curator"]["dir"],
     elasticsearch_host: node["elasticsearch"]["hostname"],

--- a/cookbooks/curator/recipes/default.rb
+++ b/cookbooks/curator/recipes/default.rb
@@ -1,0 +1,56 @@
+# Recipe for Curator
+
+# Add APT key and repository
+execute "add-apt-key" do
+  command "wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -"
+  action :nothing
+end
+
+file "/etc/apt/sources.list.d/curator.list" do
+  content "deb http://packages.elastic.co/curator/4/debian stable main"
+  notifies :run, "execute[add-apt-key]", :immediately
+end
+
+
+# Install Curator package
+apt_update "update-cache" do
+  action :update
+end
+
+apt_package "elasticsearch-curator"
+
+
+# Create its directory
+directory "#{node["curator"]["dir"]}"
+
+
+# Generate the configuration files from templates
+template "#{node["curator"]["dir"]}/actions.yml" do
+  source "actions.yml.erb"
+end
+
+template "#{node["curator"]["dir"]}/config.yml" do
+  source "config.yml.erb"
+  variables({
+    elasticsearch_host: node["elasticsearch"]["hostname"],
+    elasticsearch_port: node["elasticsearch"]["port_api"]
+  })
+end
+
+
+# Generate cron file for periodic, automatic invocation
+template "/etc/cron.d/curator-maintenance" do
+  source "curator-maintenance.erb"
+  mode '0755'
+  variables({
+    curator_dir:        node["curator"]["dir"],
+    elasticsearch_host: node["elasticsearch"]["hostname"],
+    elasticsearch_port: node["elasticsearch"]["port_api"]
+  })
+end
+
+
+# Enable and restart cron service, just in case
+service "cron" do
+  action [:enable, :restart]
+end

--- a/cookbooks/curator/templates/actions.yml.erb
+++ b/cookbooks/curator/templates/actions.yml.erb
@@ -1,0 +1,24 @@
+actions:
+  1:
+    action: delete_indices
+    description: >-
+      Delete indices older than 7 days (based on index name), for logstash-
+      prefixed indices. Ignore the error if the filter does not result in an
+      actionable list of indices (ignore_empty_list) and exit cleanly.
+    options:
+      ignore_empty_list: True
+      timeout_override:
+      continue_if_exception: False
+      disable_action: True
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-
+      exclude:
+    - filtertype: age
+      source: name
+      direction: older
+      timestring: '%Y.%m.%d'
+      unit: days
+      unit_count: 7
+      exclude:

--- a/cookbooks/curator/templates/config.yml.erb
+++ b/cookbooks/curator/templates/config.yml.erb
@@ -1,0 +1,18 @@
+client:
+  hosts:
+    - <%= @elasticsearch_host %>:<%= @elasticsearch_port %>
+  url_prefix:
+  use_ssl: False
+  certificate:
+  client_cert:
+  client_key:
+  ssl_no_validate: False
+  http_auth:
+  timeout: 30
+  master_only: False
+
+logging:
+  loglevel: INFO
+  logfile:
+  logformat: default
+  blacklist: ['elasticsearch', 'urllib3']

--- a/cookbooks/curator/templates/curator-maintenance.erb
+++ b/cookbooks/curator/templates/curator-maintenance.erb
@@ -1,0 +1,4 @@
+# Run Curator to clean up the Elasticsearch indices from older data
+# every first Sunday of every month, at midnight.
+
+00 09 * * 7 [ $(date +\%d) -le 07 ] && /usr/bin/curator --config <%= @curator_dir %>/config.yml <%= @curator_dir %>/actions.yml

--- a/cookbooks/docker/README.md
+++ b/cookbooks/docker/README.md
@@ -1,0 +1,41 @@
+# Dockerized Curator cookbook
+
+This cookbooks sets up a basic Curator configuration, ready to be
+invoked using a Docker Compose configuration file, or manually by
+invoking the `docker` command and setting up volumes and port forwarding
+using the command line.
+
+
+## Requirements
+
+The latest Docker (and preferably Docker Compose) must be installed.
+Elasticsearch Docker image tagged with version `5` must be installed.
+
+
+### Platform
+
+Depends on the latest `ubuntu:14.04` Docker image, which will be pulled
+if it is not available locally.
+
+
+### Cookbooks
+
+Depends on `docker` cookbook, version `~>1.12`.
+Depends on `elasticsearch` cookbook, version `~>0.0.1`.
+
+## Attributes
+
+- `node["curator"]["dir"]` - directory where Curator keeps its
+  configuration and data, default: `~/curator`
+
+
+## Recipes
+
+One recipe provided for invocation: `curator::default`.
+
+
+## License and Maintainer
+
+Maintainer: Filip Dimovski <rexich at riseup dot net>
+
+License: MIT

--- a/cookbooks/docker/attributes/default.rb
+++ b/cookbooks/docker/attributes/default.rb
@@ -1,0 +1,1 @@
+# Attributes for Docker

--- a/cookbooks/docker/metadata.rb
+++ b/cookbooks/docker/metadata.rb
@@ -1,0 +1,2 @@
+name    'docker'
+version '0.0.1'

--- a/cookbooks/docker/recipes/default.rb
+++ b/cookbooks/docker/recipes/default.rb
@@ -1,0 +1,50 @@
+# Recipe for Docker
+
+# Install prerequisite packages
+apt_update "update-apt-cache" do
+  action :update
+end
+
+apt_package "prerequisites-linux" do
+  package_name ["curl", "linux-image-extra-" << `uname -r`, "linux-image-extra-virtual"]
+end
+
+apt_package "prerequisites-apt" do
+  package_name ["apt-transport-https", "ca-certificates"]
+end
+
+
+# Add APT key
+execute "add-apt-key" do
+  command "curl -fsSL https://yum.dockerproject.org/gpg | sudo apt-key add -"
+end
+
+execute "add-apt-repository" do
+  command 'sudo add-apt-repository "deb https://apt.dockerproject.org/repo/ ubuntu-' << `lsb_release -cs` << ' main"'
+  notifies :update, "apt_update[update-apt-cache]", :immediately
+end
+
+
+# Install Docker Engine
+apt_package "docker-engine"
+
+
+# Add user to "docker" group
+group "docker" do
+  action :modify
+  members node["delk_user"]
+  append true
+end
+
+
+# Get Docker Compose and install it
+execute "get-docker-compose" do
+  command 'curl -L https://github.com/docker/compose/releases/download/1.10.0/docker-compose-' << `uname -s`.chomp << '-' << `uname -m`.chomp << ' -o /usr/local/bin/docker-compose'
+  creates "/usr/local/bin/docker-compose"
+end
+
+file "/usr/local/bin/docker-compose" do
+  owner "root"
+  group "root"
+  mode "0755"
+end

--- a/cookbooks/docker/templates/actions.yml.erb
+++ b/cookbooks/docker/templates/actions.yml.erb
@@ -1,0 +1,24 @@
+actions:
+  1:
+    action: delete_indices
+    description: >-
+      Delete indices older than 7 days (based on index name), for logstash-
+      prefixed indices. Ignore the error if the filter does not result in an
+      actionable list of indices (ignore_empty_list) and exit cleanly.
+    options:
+      ignore_empty_list: True
+      timeout_override:
+      continue_if_exception: False
+      disable_action: True
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-
+      exclude:
+    - filtertype: age
+      source: name
+      direction: older
+      timestring: '%Y.%m.%d'
+      unit: days
+      unit_count: 7
+      exclude:

--- a/cookbooks/docker/templates/config.yml.erb
+++ b/cookbooks/docker/templates/config.yml.erb
@@ -1,0 +1,18 @@
+client:
+  hosts:
+    - <%= @elasticsearch_host %>:<%= @elasticsearch_port %>
+  url_prefix:
+  use_ssl: False
+  certificate:
+  client_cert:
+  client_key:
+  ssl_no_validate: False
+  http_auth:
+  timeout: 30
+  master_only: False
+
+logging:
+  loglevel: INFO
+  logfile:
+  logformat: default
+  blacklist: ['elasticsearch', 'urllib3']

--- a/cookbooks/docker/templates/curator-maintenance.erb
+++ b/cookbooks/docker/templates/curator-maintenance.erb
@@ -1,0 +1,4 @@
+# Run Curator to clean up the Elasticsearch indices from older data
+# every first Sunday of every month, at midnight.
+
+00 09 * * 7 [ $(date +\%d) -le 07 ] && /usr/bin/curator --config <%= @curator_dir %>/config.yml <%= @curator_dir %>/actions.yml

--- a/cookbooks/elasticsearch/README.md
+++ b/cookbooks/elasticsearch/README.md
@@ -31,6 +31,8 @@ Depends on `docker` cookbook, version `~>1.12`.
   default: `9200`
 - `node["elasticsearch"]["port_clusters"]` - port used for communicating
   with other clusters, default: `9300`
+- `node["elasticsearch"]["minimum_master_nodes"]` - minimum number of
+  nodes that can be masters on the same cluster, default: `1`
 
 
 ## Recipes
@@ -41,5 +43,5 @@ One recipe provided for invocation: `elasticsearch::default`.
 ## License and Maintainer
 
 Maintainer: Filip Dimovski <rexich at riseup dot net>
-License: MIT
 
+License: MIT

--- a/cookbooks/elasticsearch/attributes/default.rb
+++ b/cookbooks/elasticsearch/attributes/default.rb
@@ -1,6 +1,7 @@
 # Attributes for Elasticsearch
 
-default["elasticsearch"]["dir"]           = "/home/vagrant/elasticsearch"
-default["elasticsearch"]["hostname"]      = "elasticsearch"
-default["elasticsearch"]["port_api"]      = "9200"
-default["elasticsearch"]["port_clusters"] = "9300"
+default["elasticsearch"]["dir"]                   = "/home/vagrant/elasticsearch"
+default["elasticsearch"]["hostname"]              = "elasticsearch"
+default["elasticsearch"]["port_api"]              = "9200"
+default["elasticsearch"]["port_clusters"]         = "9300"
+default["elasticsearch"]["minimum_master_nodes"]  = "1"

--- a/cookbooks/elasticsearch/attributes/default.rb
+++ b/cookbooks/elasticsearch/attributes/default.rb
@@ -1,6 +1,6 @@
 # Attributes for Elasticsearch
 
-default["elasticsearch"]["dir"]                   = "/home/vagrant/elasticsearch"
+default["elasticsearch"]["dir"]                   = "/home/#{node["delk_user"]}/elasticsearch"
 default["elasticsearch"]["hostname"]              = "elasticsearch"
 default["elasticsearch"]["port_api"]              = "9200"
 default["elasticsearch"]["port_clusters"]         = "9300"

--- a/cookbooks/elasticsearch/recipes/default.rb
+++ b/cookbooks/elasticsearch/recipes/default.rb
@@ -1,20 +1,58 @@
 # Recipe for Elasticsearch
 
 # Create directories
-directory "#{node["elasticsearch"]["dir"]}"
-directory "#{node["elasticsearch"]["dir"]}/conf"
-directory "#{node["elasticsearch"]["dir"]}/data"
-directory "#{node["elasticsearch"]["dir"]}/logs"
+directory "#{node["elasticsearch"]["dir"]}" do
+  owner node["delk_user"]
+  group node["delk_user"]
+end
+
+directory "#{node["elasticsearch"]["dir"]}/conf" do
+  owner node["delk_user"]
+  group node["delk_user"]
+end
+
+directory "#{node["elasticsearch"]["dir"]}/data" do
+  owner node["delk_user"]
+  group node["delk_user"]
+end
+
+directory "#{node["elasticsearch"]["dir"]}/logs" do
+  owner node["delk_user"]
+  group node["delk_user"]
+end
+
 
 # Create the Dockerfile
 file "#{node["elasticsearch"]["dir"]}/Dockerfile" do
   content "FROM elasticsearch:5"
+  owner node["delk_user"]
+  group node["delk_user"]
+
 end
+
 
 # Generate the configuration file from a template
 template "#{node["elasticsearch"]["dir"]}/conf/elasticsearch.yml" do
   source "elasticsearch.yml.erb"
+  owner node["delk_user"]
+  group node["delk_user"]
   variables({
     min_master_nodes: node["elasticsearch"]["minimum_master_nodes"]
   })
+end
+
+
+# Create a configuration file to load kernel settings that will raise
+# limit of maximim files that can be mapped, required for Elasticsearch
+execute "reload-sysctl" do
+  command "sysctl -q --system"
+  action :nothing
+end
+
+file "/etc/sysctl.d/99-increase-max-map-count.conf" do
+  content "vm.max_map_count=262144"
+  mode "0644"
+  owner "root"
+  group "root"
+  notifies :run, "execute[reload-sysctl]", :immediately
 end

--- a/cookbooks/elasticsearch/recipes/default.rb
+++ b/cookbooks/elasticsearch/recipes/default.rb
@@ -14,4 +14,7 @@ end
 # Generate the configuration file from a template
 template "#{node["elasticsearch"]["dir"]}/conf/elasticsearch.yml" do
   source "elasticsearch.yml.erb"
+  variables({
+    min_master_nodes: node["elasticsearch"]["minimum_master_nodes"]
+  })
 end

--- a/cookbooks/elasticsearch/templates/elasticsearch.yml.erb
+++ b/cookbooks/elasticsearch/templates/elasticsearch.yml.erb
@@ -5,7 +5,7 @@ network.host: 0.0.0.0
 # One node is enough to form a cluster.
 # See: https://www.elastic.co/guide/en/elasticsearch/reference/current/
 # important-settings.html#minimum_master_nodes
-discovery.zen.minimum_master_nodes: 1
+discovery.zen.minimum_master_nodes: <%= @min_master_nodes %>
 
 # Set up a cluster; all nodes must have the same cluster name!
 cluster.name: production

--- a/cookbooks/kibana/README.md
+++ b/cookbooks/kibana/README.md
@@ -1,6 +1,6 @@
-# Dockerized Logstash cookbook
+# Dockerized Kibana cookbook
 
-This cookbooks sets up a basic Logstash configuration, ready to be
+This cookbooks sets up a basic Kibana configuration, ready to be
 invoked using a Docker Compose configuration file, or manually by
 invoking the `docker` command and setting up volumes and port forwarding
 using the command line.
@@ -9,7 +9,6 @@ using the command line.
 ## Requirements
 
 The latest Docker (and preferably Docker Compose) must be installed.
-Elasticsearch Docker image tagged with version `5` must be installed.
 
 
 ### Platform
@@ -25,15 +24,15 @@ Depends on `elasticsearch` cookbook, version `~>0.0.1`.
 
 ## Attributes
 
-- `node["logstash"]["dir"]` - directory where Logstash keeps its
-  configuration and data, default: `~/logstash`
-- `node["logstash"]["port"]` - port used for communication,
-  default: `5000`
+- `node["kibana"]["dir"]` - directory where Kibana keeps
+  its configuration, data, and logs, default: `~/elasticsearch`
+- `node["kibana"]["port"]` - port used for server communication,
+  default: `5601`
 
 
 ## Recipes
 
-One recipe provided for invocation: `logstash::default`.
+One recipe provided for invocation: `kibana::default`.
 
 
 ## License and Maintainer

--- a/cookbooks/kibana/attributes/default.rb
+++ b/cookbooks/kibana/attributes/default.rb
@@ -1,4 +1,4 @@
 # Attributes for Kibana
 
-default["kibana"]["dir"]   = "/home/vagrant/kibana"
+default["kibana"]["dir"]   = "/home/#{node["delk_user"]}/kibana"
 default["kibana"]["port"]  = "5601"

--- a/cookbooks/kibana/attributes/default.rb
+++ b/cookbooks/kibana/attributes/default.rb
@@ -1,0 +1,4 @@
+# Attributes for Kibana
+
+default["kibana"]["dir"]   = "/home/vagrant/kibana"
+default["kibana"]["port"]  = "5601"

--- a/cookbooks/kibana/metadata.rb
+++ b/cookbooks/kibana/metadata.rb
@@ -1,0 +1,4 @@
+name    'kibana'
+version '0.0.1'
+
+depends 'elasticsearch', '>=0.0.1'

--- a/cookbooks/kibana/recipes/default.rb
+++ b/cookbooks/kibana/recipes/default.rb
@@ -1,21 +1,43 @@
 # Recipe for Kibana
 
 # Create its directory
-directory "#{node["kibana"]["dir"]}"
-directory "#{node["kibana"]["dir"]}/conf"
+directory "#{node["kibana"]["dir"]}" do
+  owner node["delk_user"]
+  group node["delk_user"]
+end
+
+directory "#{node["kibana"]["dir"]}/conf" do
+  owner node["delk_user"]
+  group node["delk_user"]
+end
 
 
 # Generate the Dockerfile from a template
 template "#{node["kibana"]["dir"]}/Dockerfile" do
   source "Dockerfile.erb"
+  owner node["delk_user"]
+  group node["delk_user"]
 end
 
 
 # Generate configuration files from templates
 template "#{node["kibana"]["dir"]}/conf/kibana.yml" do
   source "kibana.yml.erb"
+  owner node["delk_user"]
+  group node["delk_user"]
+  variables({
+    kibana_port:        node["kibana"]["port"],
+    elasticsearch_host: node["elasticsearch"]["hostname"],
+    elasticsearch_port: node["elasticsearch"]["port_api"]
+  })
 end
 
 template "#{node["kibana"]["dir"]}/startup.sh" do
   source "startup.sh.erb"
+  owner node["delk_user"]
+  group node["delk_user"]
+  variables({
+    elasticsearch_host: node["elasticsearch"]["hostname"],
+    elasticsearch_port: node["elasticsearch"]["port_api"]
+  })
 end

--- a/cookbooks/kibana/recipes/default.rb
+++ b/cookbooks/kibana/recipes/default.rb
@@ -1,0 +1,21 @@
+# Recipe for Kibana
+
+# Create its directory
+directory "#{node["kibana"]["dir"]}"
+directory "#{node["kibana"]["dir"]}/conf"
+
+
+# Generate the Dockerfile from a template
+template "#{node["kibana"]["dir"]}/Dockerfile" do
+  source "Dockerfile.erb"
+end
+
+
+# Generate configuration files from templates
+template "#{node["kibana"]["dir"]}/conf/kibana.yml" do
+  source "kibana.yml.erb"
+end
+
+template "#{node["kibana"]["dir"]}/startup.sh" do
+  source "startup.sh.erb"
+end

--- a/cookbooks/kibana/templates/Dockerfile.erb
+++ b/cookbooks/kibana/templates/Dockerfile.erb
@@ -1,0 +1,11 @@
+FROM kibana:5
+
+# The following is a crude hack, that will make Kibana wait until
+# Elasticsearch server is up and running, and then connect on it.
+
+COPY startup.sh /tmp/startup.sh
+RUN apt-get -qq update && \
+    apt-get install -qq -y netcat bzip2 && \
+    chmod +x /tmp/startup.sh
+
+CMD ["/tmp/startup.sh"]

--- a/cookbooks/kibana/templates/kibana.yml.erb
+++ b/cookbooks/kibana/templates/kibana.yml.erb
@@ -1,0 +1,92 @@
+# Kibana is served by a back end server. This setting specifies the port to use.
+server.port: <%= node["kibana"]["port"] %>
+
+# This setting specifies the IP address of the back end server.
+server.host: "0.0.0.0"
+
+# Enables you to specify a path to mount Kibana at if you are running behind a proxy. This setting
+# cannot end in a slash.
+# server.basePath: ""
+
+# The maximum payload size in bytes for incoming server requests.
+# server.maxPayloadBytes: 1048576
+
+# The Kibana server's name.  This is used for display purposes.
+# server.name: "your-hostname"
+
+# The URL of the Elasticsearch instance to use for all your queries.
+elasticsearch.url: "http://<%= node["elasticsearch"]["hostname"] %>:<%= node["elasticsearch"]["port_api"] %>"
+
+# When this setting’s value is true Kibana uses the hostname specified in the server.host
+# setting. When the value of this setting is false, Kibana uses the hostname of the host
+# that connects to this Kibana instance.
+# elasticsearch.preserveHost: true
+
+# Kibana uses an index in Elasticsearch to store saved searches, visualizations and
+# dashboards. Kibana creates a new index if the index doesn’t already exist.
+# kibana.index: ".kibana"
+
+# The default application to load.
+# kibana.defaultAppId: "discover"
+
+# If your Elasticsearch is protected with basic authentication, these settings provide
+# the username and password that the Kibana server uses to perform maintenance on the Kibana
+# index at startup. Your Kibana users still need to authenticate with Elasticsearch, which
+# is proxied through the Kibana server.
+# elasticsearch.username: "user"
+# elasticsearch.password: "pass"
+
+# Paths to the PEM-format SSL certificate and SSL key files, respectively. These
+# files enable SSL for outgoing requests from the Kibana server to the browser.
+# server.ssl.cert: /path/to/your/server.crt
+# server.ssl.key: /path/to/your/server.key
+
+# Optional settings that provide the paths to the PEM-format SSL certificate and key files.
+# These files validate that your Elasticsearch backend uses the same key files.
+# elasticsearch.ssl.cert: /path/to/your/client.crt
+# elasticsearch.ssl.key: /path/to/your/client.key
+
+# Optional setting that enables you to specify a path to the PEM file for the certificate
+# authority for your Elasticsearch instance.
+# elasticsearch.ssl.ca: /path/to/your/CA.pem
+
+# To disregard the validity of SSL certificates, change this setting’s value to false.
+# elasticsearch.ssl.verify: true
+
+# Time in milliseconds to wait for Elasticsearch to respond to pings. Defaults to the value of
+# the elasticsearch.requestTimeout setting.
+# elasticsearch.pingTimeout: 1500
+
+# Time in milliseconds to wait for responses from the back end or Elasticsearch. This value
+# must be a positive integer.
+# elasticsearch.requestTimeout: 30000
+
+# List of Kibana client-side headers to send to Elasticsearch. To send *no* client-side
+# headers, set this value to [] (an empty list).
+# elasticsearch.requestHeadersWhitelist: [ authorization ]
+
+# Time in milliseconds for Elasticsearch to wait for responses from shards. Set to 0 to disable.
+# elasticsearch.shardTimeout: 0
+
+# Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying.
+# elasticsearch.startupTimeout: 5000
+
+# Specifies the path where Kibana creates the process ID file.
+# pid.file: /var/run/kibana.pid
+
+# Enables you specify a file where Kibana stores log output.
+# logging.dest: stdout
+
+# Set the value of this setting to true to suppress all logging output.
+# logging.silent: false
+
+# Set the value of this setting to true to suppress all logging output other than error messages.
+# logging.quiet: false
+
+# Set the value of this setting to true to log all events, including system usage information
+# and all requests.
+# logging.verbose: false
+
+# Set the interval in milliseconds to sample system and process performance
+# metrics. Minimum is 100ms. Defaults to 10000.
+# ops.interval: 10000

--- a/cookbooks/kibana/templates/kibana.yml.erb
+++ b/cookbooks/kibana/templates/kibana.yml.erb
@@ -1,5 +1,5 @@
 # Kibana is served by a back end server. This setting specifies the port to use.
-server.port: <%= node["kibana"]["port"] %>
+server.port: <%= @kibana_port %>
 
 # This setting specifies the IP address of the back end server.
 server.host: "0.0.0.0"
@@ -15,7 +15,7 @@ server.host: "0.0.0.0"
 # server.name: "your-hostname"
 
 # The URL of the Elasticsearch instance to use for all your queries.
-elasticsearch.url: "http://<%= node["elasticsearch"]["hostname"] %>:<%= node["elasticsearch"]["port_api"] %>"
+elasticsearch.url: "http://<%= @elasticsearch_host %>:<%= @elasticsearch_port %>"
 
 # When this setting’s value is true Kibana uses the hostname specified in the server.host
 # setting. When the value of this setting is false, Kibana uses the hostname of the host

--- a/cookbooks/kibana/templates/startup.sh.erb
+++ b/cookbooks/kibana/templates/startup.sh.erb
@@ -3,7 +3,7 @@
 # Wait for Elasticsearch to be ready before starting Kibana.
 echo "Waiting for Elasticsearch to come online..."
 while true; do
-    nc -q 1 <%= node["elasticsearch"]["hostname"] %> <%= node["elasticsearch"]["port_api"] %> 2>/dev/null && break
+    nc -q 1 <%= @elasticsearch_host %> <%= @elasticsearch_port %> 2>/dev/null && break
 done
 
 echo "Elasticsearch is up and running. Starting Kibana..."

--- a/cookbooks/kibana/templates/startup.sh.erb
+++ b/cookbooks/kibana/templates/startup.sh.erb
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Wait for Elasticsearch to be ready before starting Kibana.
+echo "Waiting for Elasticsearch to come online..."
+while true; do
+    nc -q 1 <%= node["elasticsearch"]["hostname"] %> <%= node["elasticsearch"]["port_api"] %> 2>/dev/null && break
+done
+
+echo "Elasticsearch is up and running. Starting Kibana..."
+exec kibana

--- a/cookbooks/logstash/attributes/default.rb
+++ b/cookbooks/logstash/attributes/default.rb
@@ -1,4 +1,4 @@
 # Attributes for Logstash
 
-default["logstash"]["dir"]    = "/home/vagrant/logstash"
+default["logstash"]["dir"]    = "/home/#{node["delk_user"]}/logstash"
 default["logstash"]["port"]   = "5000"

--- a/cookbooks/logstash/recipes/default.rb
+++ b/cookbooks/logstash/recipes/default.rb
@@ -13,4 +13,9 @@ end
 # Create the configuration file from a template
 template "#{node["logstash"]["dir"]}/conf/logstash.conf" do
   source "logstash.conf.erb"
+  variables({
+    logstash_port:      node["logstash"]["port"],
+    elasticsearch_host: node["elasticsearch"]["hostname"],
+    elasticsearch_port: node["elasticsearch"]["port_api"]
+  })
 end

--- a/cookbooks/logstash/recipes/default.rb
+++ b/cookbooks/logstash/recipes/default.rb
@@ -1,18 +1,34 @@
 # Logstash recipe
 
 # Create directories
-directory "#{node["logstash"]["dir"]}"
-directory "#{node["logstash"]["dir"]}/conf"
-directory "#{node["logstash"]["dir"]}/data"
+directory "#{node["logstash"]["dir"]}" do
+  owner node["delk_user"]
+  group node["delk_user"]
+end
+
+directory "#{node["logstash"]["dir"]}/conf" do
+  owner node["delk_user"]
+  group node["delk_user"]
+end
+
+directory "#{node["logstash"]["dir"]}/data" do
+  owner node["delk_user"]
+  group node["delk_user"]
+end
+
 
 # Create the Dockerfile
 file "#{node["logstash"]["dir"]}/Dockerfile" do
   content "FROM logstash:5"
+  owner node["delk_user"]
+  group node["delk_user"]
 end
 
 # Create the configuration file from a template
 template "#{node["logstash"]["dir"]}/conf/logstash.conf" do
   source "logstash.conf.erb"
+  owner node["delk_user"]
+  group node["delk_user"]
   variables({
     logstash_port:      node["logstash"]["port"],
     elasticsearch_host: node["elasticsearch"]["hostname"],

--- a/cookbooks/logstash/templates/logstash.conf.erb
+++ b/cookbooks/logstash/templates/logstash.conf.erb
@@ -1,15 +1,15 @@
 input {
     tcp {
-        port => <%= node["logstash"]["port"] %>
+        port => <%= @logstash_port %>
     }
     udp {
-        port => <%= node["logstash"]["port"] %>
+        port => <%= @logstash_port %>
     }
 }
 
 output {
     elasticsearch {
-        hosts => "<%= node["elasticsearch"]["hostname"] %>:<%= node["elasticsearch"]["port_api"] %>"
+        hosts => "<%= @elasticsearch_host %>:<%= @elasticsearch_port %>"
     }
     stdout {}
 }

--- a/cookbooks/post-setup/README.md
+++ b/cookbooks/post-setup/README.md
@@ -1,0 +1,43 @@
+# DELK Post-setup Cookbook
+
+This cookbooks sets up the Docker Compose file, that will start the
+three microservices (Elasticsearch, Logstash, and Kibana) together, put
+them on the same Docker network to allow them to communicate, and be
+responsible for controlling their execution (orchestration of tasks).
+
+
+## Requirements
+
+The latest Docker (and preferably Docker Compose) must be installed.
+All of the cookbooks listed in the [cookbooks](#cookbooks) section must
+be provisioned and converged. 
+
+
+### Platform
+
+Platform dependencies are same as the ones of the depending cookbooks.
+
+
+### Cookbooks
+
+Depends on `docker` cookbook, version `~>0.0.1`.
+Depends on `elasticsearch` cookbook, version `~>0.0.1`.
+Depends on `logstash` cookbook, version `~>0.0.1`.
+Depends on `kibana` cookbook, version `~>0.0.1`.
+
+
+## Attributes
+
+None.
+
+
+## Recipes
+
+One recipe provided for invocation: `post-setup::default`.
+
+
+## License and Maintainer
+
+Maintainer: Filip Dimovski <rexich at riseup dot net>
+
+License: MIT

--- a/cookbooks/post-setup/attributes/default.rb
+++ b/cookbooks/post-setup/attributes/default.rb
@@ -1,0 +1,1 @@
+# Attributes for DELK post-setup

--- a/cookbooks/post-setup/metadata.rb
+++ b/cookbooks/post-setup/metadata.rb
@@ -1,0 +1,6 @@
+name    'post-setup'
+version '0.0.1'
+
+depends 'elasticsearch', '>=0.0.1'
+depends 'logstash', '>=0.0.1'
+depends 'kibana', '>=0.0.1'

--- a/cookbooks/post-setup/recipes/default.rb
+++ b/cookbooks/post-setup/recipes/default.rb
@@ -1,0 +1,30 @@
+# Recipe for DELK post-setup
+
+# Create the Docker Compose file
+template "/home/#{node["delk_user"]}/docker-compose.yml" do
+  source "docker-compose.yml.erb"
+  owner node["delk_user"]
+  group node["delk_user"]
+  variables({
+    elasticsearch_port_api:       node["elasticsearch"]["port_api"],
+    elasticsearch_port_clusters:  node["elasticsearch"]["port_clusters"],
+    docker_network_name:          node["delk_net"],
+    logstash_port:                node["logstash"]["port"],
+    kibana_port:                  node["kibana"]["port"]
+  })
+end
+
+
+# Create a configuration file to emit rsyslog output to port 5000,
+# so that Logstash will collect it and forward it to Elasticsearch
+service 'rsyslog' do
+  action :nothing
+end
+
+file "/etc/rsyslog.d/99-emit-logs.conf" do
+  content '*.*     @@localhost:5000'
+  owner "root"
+  group "root"
+  mode "0644"
+  notifies :restart, "service[rsyslog]", :immediately
+end

--- a/cookbooks/post-setup/templates/docker-compose.yml.erb
+++ b/cookbooks/post-setup/templates/docker-compose.yml.erb
@@ -1,0 +1,64 @@
+version: '2'
+
+services:
+  # Elasticseach microservice definition
+  elasticsearch:
+    # Directory containing the Dockerfile
+    build: elasticsearch/
+    # Map ports between the host machine and the Docker instance:
+    # Port 9200 - access to Elasticsearch API
+    # Port 9300 - cluster communication
+    ports:
+      - "<%= @elasticsearch_port_api %>:<%= @elasticsearch_port_api %>"
+      - "<%= @elasticsearch_port_clusters %>:<%= @elasticsearch_port_clusters %>"
+    # Elasticseach requires lots of heap memory for high performance.
+    # The underlying library is Lucene, and the library's data is stored
+    # as a set of immutable files, cached by the Linux kernel in the
+    # unused RAM buffers. Let Elasticseach use 50% of RAM for its heap,
+    # leave the rest for Lucene to increase speed; or: ES_HEAP_SIZE=1g
+    environment:
+      ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+    # This container is on the same Docker network as the others
+    # so they can communicate between each other
+    networks:
+      - <%= @docker_network_name %>
+    # Share the data and configuration directories/files using volumes
+    volumes:
+      - ./elasticsearch/data:/usr/share/elasticsearch/data
+      - ./elasticsearch/conf:/usr/share/elasticsearch/conf
+      - ./elasticsearch/logs:/usr/share/elasticsearch/logs
+  # Logstash microservice definition
+  logstash:
+    # Directory containing the Dockerfile
+    build: logstash/
+    # Override the default configuration directory
+    command: -f /etc/logstash/conf.d/
+    # The configuration files are stored in a mapped volume
+    volumes:
+      - ./logstash/conf:/etc/logstash/conf.d
+    # Map this port so we can send the rsyslog from host to Logstash
+    ports:
+      - "<%= @logstash_port %>:<%= @logstash_port %>"
+    # Put this container on the same Docker network as the others
+    # so they can communicate between each other
+    networks:
+      - <%= @docker_network_name %>
+  # Kibana microservice definition
+  kibana:
+    build: kibana/
+    # Volume for Kibana's configuration files
+    volumes:
+      - ./kibana/config/:/opt/kibana/config/
+    # Ports for accessing Kibana
+    # (open http://localhost:5601 in your browser to see it)
+    ports:
+      - "<%= @kibana_port %>:<%= @kibana_port %>"
+    # Put this container on the same Docker network as the others
+    # so they can communicate between each other
+    networks:
+      - <%= @docker_network_name %>
+
+# One common network for the microservices to communicate together
+networks:
+  <%= @docker_network_name %>:
+    driver: bridge

--- a/roles/delk.json
+++ b/roles/delk.json
@@ -1,0 +1,20 @@
+{
+    "name": "delk",
+    "description": "Sets up a complete Docker and ELK stack",
+    "chef_type": "role",
+    "json_class": "Chef::Role",
+    "default_attributes": {
+      "delk_user": "vagrant",
+      "delk_net": "delk"
+    },
+    "override_attributes": {
+    },
+    "run_list": [
+        "recipe[docker]",
+        "recipe[elasticsearch]",
+        "recipe[logstash]",
+        "recipe[curator]",
+        "recipe[kibana]",
+        "recipe[post-setup]"
+    ]
+}


### PR DESCRIPTION
Add Curator and Kibana cookbooks.

Write a role to define runlist and attributs easily for all cookbooks.

Refactor recipes of all cookbooks:
- fix permissions and ownership of files and directories;
- triple-checked and rewrote all documentation for each cookbook;
- all Erubis templates use instance variables instead of node[..].

Write Docker cookbook, installs Engine and Composer.
Write DELK post-setup cookbook, generates Docker Compose YAML.
Configure sysctl parameter for Elasticsearch heap memory requirements.
Configure rsyslog log forwarding on port 5000.